### PR TITLE
small fix to rbac resources to allow airflow user to read pod logs

### DIFF
--- a/scripts/kube/templates/airflow.template.yaml
+++ b/scripts/kube/templates/airflow.template.yaml
@@ -31,7 +31,7 @@ metadata:
   name: airflow
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods"]
+  resources: ["pods", "pods/log"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]


### PR DESCRIPTION
Copied from issue #13 

When launching a custom DAG using kubernetesPodOperator airflow correctly launched the pod but returned a failed status on the job. The log produced this error:

"status":"Failure","message":"pods \"airflow-dag-c4eaf498\" is forbidden: User \"system:serviceaccount:airflow-example:airflow\" cannot get resource \"pods/log\"

This was caused by the rbac group not having correct permissions in the resources. It should include "pods/log" to allow the airflow user to read the pod logs.

Once this edit was made the logs were accessed and airflow showed success.

https://kubernetes.io/docs/reference/access-authn-authz/rbac/ REF: Referring to resources.